### PR TITLE
Fixed warning in PreferenceWindowController.m

### DIFF
--- a/mclock/PreferenceWindowController.m
+++ b/mclock/PreferenceWindowController.m
@@ -76,7 +76,7 @@
 
 - (IBAction) preview:(id) sender{
     
-    NSString *zone = [NSString stringWithFormat:[timeZone stringValue]];
+    NSString *zone = [NSString stringWithFormat: @"%@", [timeZone stringValue]];
     
     NSDateFormatter *formatter = [[[NSDateFormatter alloc] init] autorelease];
     [formatter setDateFormat:[formatString stringValue]];


### PR DESCRIPTION
Fixes "Format string is not a string literal (potentially insecure)" warning by proper usage of NSString stringWithFormat notation within preview:(id) sender
